### PR TITLE
Add follow location opt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "madeiramadeirabr/http-client",
     "description": "A package to consume Rest APIs with multi-curl and mock return",
-    "version": "1.0.33",
+    "version": "1.0.34",
     "type": "library",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "madeiramadeirabr/http-client",
     "description": "A package to consume Rest APIs with multi-curl and mock return",
-    "version": "1.0.34",
+    "version": "1.0.35",
     "type": "library",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "madeiramadeirabr/http-client",
     "description": "A package to consume Rest APIs with multi-curl and mock return",
-    "version": "1.0.35",
+    "version": "1.0.36",
     "type": "library",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "madeiramadeirabr/http-client",
     "description": "A package to consume Rest APIs with multi-curl and mock return",
-    "version": "1.0.32",
+    "version": "1.0.33",
     "type": "library",
     "authors": [
         {

--- a/src/Curl/CurlBuilder.php
+++ b/src/Curl/CurlBuilder.php
@@ -36,6 +36,7 @@ abstract class CurlBuilder
         curl_setopt($ch, CURLOPT_HEADER, 1);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);
+        curl_setopt($ch, CURLOPT_FOLLOWLOCATION,true);
 
         $curlOptions = $this->request->getOptions()['curlSettings'] ?? [];
         foreach($curlOptions as $key => $option) {

--- a/src/Http/CacheProxyHttpClient.php
+++ b/src/Http/CacheProxyHttpClient.php
@@ -135,7 +135,7 @@ class CacheProxyHttpClient implements IHttpClient
         }
         $response = $this->httpClient->request($method, $url, $body, $headers, $options);
         if(in_array($response->getStatus(), self::SUCCESS_STATUS)  ) {
-            $this->cacheResponse($requestHash);
+            $this->cacheResponse($requestHash, $response);
         }
         return $response;
     }
@@ -178,9 +178,9 @@ class CacheProxyHttpClient implements IHttpClient
         return $this->httpClient->getUrl($url, $options);
     }
 
-    private function cacheResponse(string $hash): bool
+    private function cacheResponse(string $hash, IHttpResponse $response): bool
     {
-        $this->cache[$hash] = $this->getLastTransaction()->getResponse();
+        $this->cache[$hash] = $response;
         return true;
     }
 

--- a/src/Http/CacheProxyHttpClient.php
+++ b/src/Http/CacheProxyHttpClient.php
@@ -29,6 +29,23 @@ class CacheProxyHttpClient implements IHttpClient
     }
 
     /**
+     * @param string $serviceName
+     * @return IHttpClient
+     */
+    public function setServiceName(?string $serviceName): IHttpClient
+    {
+        return $this->httpClient->setServiceName($serviceName);
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceName(): ?string
+    {
+        return $this->httpClient->getServiceName();
+    }
+
+    /**
      * @param array $headers
      * @return IHttpClient
      */

--- a/src/Http/CacheProxyHttpClient.php
+++ b/src/Http/CacheProxyHttpClient.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace MadeiraMadeiraBr\HttpClient\Http;
+
+class CacheProxyHttpClient implements IHttpClient
+{
+    /**
+     * @var array
+     */
+    private $cache = [];
+
+    /**
+     * @var IHttpClient
+     */
+    private $httpClient;
+
+    /**
+     * CacheProxyHttpClient constructor.
+     * @param IHttpClient $httpClient
+     */
+    public function __construct(IHttpClient $httpClient)
+    {
+        $this->httpClient = $httpClient;
+    }
+
+    /**
+     * @param array $headers
+     * @return IHttpClient
+     */
+    public function setHeaders(array $headers): IHttpClient
+    {
+        return $this->httpClient->setHeaders($headers);
+    }
+
+    /**
+     * @param array $header
+     * @return IHttpClient
+     */
+    public function pushHeader(array $header): IHttpClient
+    {
+        return $this->httpClient->pushHeader($header);
+    }
+
+    /**
+     * @param array $options
+     * @return IHttpClient
+     */
+    public function setOptions(array $options): IHttpClient
+    {
+        return $this->httpClient->setOptions($options);
+    }
+
+    /**
+     * @param array $option
+     * @return IHttpClient
+     */
+    public function pushOption(array $option): IHttpClient
+    {
+        return $this->httpClient->pushOption($option);
+    }
+
+    /**
+     * @param string $url
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function get(string $url, ?array $headers = null, ?array $options = null): ?array
+    {
+        return $this->request(ITransaction::HTTP_METHOD_GET, $url, null, $headers, $options)
+            ->getDecodedBody();
+    }
+
+    /**
+     * @param string $url
+     * @param array $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function post(string $url, array $body, ?array $headers = null, ?array $options = null): ?array
+    {
+        return $this->httpClient->post($url, $body, $headers, $options);
+    }
+
+    /**
+     * @param string $url
+     * @param array $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function put(string $url, array $body, ?array $headers = null, ?array $options = null): ?array
+    {
+        return $this->httpClient->put($url, $body, $headers, $options);
+    }
+
+    /**
+     * @param string $url
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function delete(string $url, ?array $headers = null, ?array $options = null): ?array
+    {
+        return $this->httpClient->delete($url, $headers, $options);
+    }
+
+    /**
+     * @param string $method
+     * @param string $url
+     * @param array|null $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return IHttpResponse
+     */
+    public function request(
+        string $method,
+        string $url,
+        ?array $body = null,
+        ?array $headers = null,
+        ?array $options = null): IHttpResponse
+    {
+        $requestHash = $this->generateRequestHash($method, $this->getUrl($url, $options), $body);
+        if(isset($this->cache[$requestHash])) {
+            return $this->cache[$requestHash];
+        }
+        $response = $this->httpClient->request($method, $url, $body, $headers, $options);
+        if($response->getStatus() == 200) {
+            $this->cacheResponse($requestHash);
+        }
+        return $response;
+    }
+
+    /**
+     * @return ITransaction|null
+     */
+    public function getLastTransaction(): ?ITransaction
+    {
+        return $this->httpClient->getLastTransaction();
+    }
+
+    /**
+     * @return IHttpResponse|null
+     */
+    public function getLastResponse(): ?IHttpResponse
+    {
+        return $this->httpClient->getLastResponse();
+    }
+
+    /**
+     * @return string
+     */
+    public function getBaseUrl(): string
+    {
+        return $this->httpClient->getBaseUrl();
+    }
+
+    /**
+     * @param string $baseUrl
+     * @return IHttpClient
+     */
+    public function setBaseUrl(string $baseUrl): IHttpClient
+    {
+        return $this->httpClient->setBaseUrl($baseUrl);
+    }
+
+    public function getUrl(string $url, ?array $options): string
+    {
+        return $this->httpClient->getUrl($url, $options);
+    }
+
+    private function cacheResponse(string $hash): bool
+    {
+        $this->cache[$hash] = $this->getLastTransaction()->getResponse();
+        return true;
+    }
+
+    private function generateRequestHash(string $method, string $url, ?array $body = null): int
+    {
+        $body = json_encode($body) ?? '';
+        return crc32($method . $url . $body);
+    }
+}

--- a/src/Http/CacheProxyHttpClient.php
+++ b/src/Http/CacheProxyHttpClient.php
@@ -7,6 +7,11 @@ class CacheProxyHttpClient implements IHttpClient
     /**
      * @var array
      */
+    const SUCCESS_STATUS = [200, 201];
+
+    /**
+     * @var array
+     */
     private $cache = [];
 
     /**
@@ -80,7 +85,8 @@ class CacheProxyHttpClient implements IHttpClient
      */
     public function post(string $url, array $body, ?array $headers = null, ?array $options = null): ?array
     {
-        return $this->httpClient->post($url, $body, $headers, $options);
+        return $this->request(ITransaction::HTTP_METHOD_POST, $url, $body, $headers, $options)
+            ->getDecodedBody();
     }
 
     /**
@@ -92,7 +98,8 @@ class CacheProxyHttpClient implements IHttpClient
      */
     public function put(string $url, array $body, ?array $headers = null, ?array $options = null): ?array
     {
-        return $this->httpClient->put($url, $body, $headers, $options);
+        return $this->request(ITransaction::HTTP_METHOD_PUT, $url, $body, $headers, $options)
+            ->getDecodedBody();
     }
 
     /**
@@ -103,7 +110,8 @@ class CacheProxyHttpClient implements IHttpClient
      */
     public function delete(string $url, ?array $headers = null, ?array $options = null): ?array
     {
-        return $this->httpClient->delete($url, $headers, $options);
+        return $this->request(ITransaction::HTTP_METHOD_DELETE, $url, null, $headers, $options)
+            ->getDecodedBody();
     }
 
     /**
@@ -126,7 +134,7 @@ class CacheProxyHttpClient implements IHttpClient
             return $this->cache[$requestHash];
         }
         $response = $this->httpClient->request($method, $url, $body, $headers, $options);
-        if($response->getStatus() == 200) {
+        if(in_array($response->getStatus(), self::SUCCESS_STATUS)  ) {
             $this->cacheResponse($requestHash);
         }
         return $response;

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -12,6 +12,11 @@ class HttpClient implements IHttpClient
     /**
      * @var string
      */
+    private $serviceName;
+
+    /**
+     * @var string
+     */
     private $baseUrl;
 
     /**
@@ -62,6 +67,24 @@ class HttpClient implements IHttpClient
         $this->options = $options ?? $this->options;
         $this->requestBodyHandler = $requestBodyHandler ?? new JsonBodyHandler();
         $this->responseBodyHandler = $responseBodyHandler ?? new JsonBodyHandler();
+    }
+
+    /**
+     * @param string $serviceName
+     * @return IHttpClient
+     */
+    public function setServiceName(?string $serviceName): IHttpClient
+    {
+        $this->serviceName = $serviceName;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
     }
 
     /**
@@ -184,13 +207,16 @@ class HttpClient implements IHttpClient
             return $mock->get();
         }
 
-        $this->lastTransaction = (new Transaction(
+        $transaction = new Transaction(
             $this->buildRequest(
                 $method,
                 $url,
                 $body,
                 $headers,
-                $options)));
+                $options));
+
+        $transaction->setServiceName($this->serviceName);
+        $this->lastTransaction = ($transaction);
 
         $response = $this->lastTransaction->run()->getResponse();
         $response->setBodyHandler($options['responseBodyHandler'] ?? $this->responseBodyHandler);

--- a/src/Http/HttpClient.php
+++ b/src/Http/HttpClient.php
@@ -7,7 +7,7 @@ use MadeiraMadeiraBr\HttpClient\BodyHandlers\JsonBodyHandler;
 use MadeiraMadeiraBr\HttpClient\Mock\MockHandler;
 use MadeiraMadeiraBr\HttpClient\ResponseQualityAssurance\ResponseQualityAssurance;
 
-class HttpClient
+class HttpClient implements IHttpClient
 {
     /**
      * @var string
@@ -66,16 +66,20 @@ class HttpClient
 
     /**
      * @param array $headers
-     * @return HttpClient
+     * @return IHttpClient
      */
-    public function setHeaders(array $headers): HttpClient
+    public function setHeaders(array $headers): IHttpClient
     {
         $headers = array_change_key_case($headers, CASE_LOWER);
         $this->headers = $headers;
         return $this;
     }
 
-    public function pushHeader(array $header)
+    /**
+     * @param array $header
+     * @return IHttpClient
+     */
+    public function pushHeader(array $header): IHttpClient
     {
         $header = array_change_key_case($header, CASE_LOWER);
         $this->headers = array_replace($this->headers, $header);
@@ -84,15 +88,19 @@ class HttpClient
 
     /**
      * @param array $options
-     * @return HttpClient
+     * @return IHttpClient
      */
-    public function setOptions(array $options): HttpClient
+    public function setOptions(array $options): IHttpClient
     {
         $this->options = $options;
         return $this;
     }
 
-    public function pushOption(array $option): HttpClient
+    /**
+     * @param array $option
+     * @return IHttpClient
+     */
+    public function pushOption(array $option): IHttpClient
     {
         $curlSettings = $this->options['curlSettings'] ?? [];
         if(isset($this->options['curlSettings'])
@@ -237,7 +245,7 @@ class HttpClient
      * @param array|null $options
      * @return string
      */
-    private function getUrl(string $url, ?array $options)
+    public function getUrl(string $url, ?array $options): string
     {
        if(isset($options['baseUrl'])) {
            return $options['baseUrl'] . $url;
@@ -255,9 +263,9 @@ class HttpClient
 
     /**
      * @param string $baseUrl
-     * @return HttpClient
+     * @return IHttpClient
      */
-    public function setBaseUrl(string $baseUrl): HttpClient
+    public function setBaseUrl(string $baseUrl): IHttpClient
     {
         $this->baseUrl = $baseUrl;
         return $this;

--- a/src/Http/IHttpClient.php
+++ b/src/Http/IHttpClient.php
@@ -5,6 +5,17 @@ namespace MadeiraMadeiraBr\HttpClient\Http;
 interface IHttpClient
 {
     /**
+     * @param string $serviceName
+     * @return IHttpClient
+     */
+    public function setServiceName(?string $serviceName): IHttpClient;
+
+    /**
+     * @return string
+     */
+    public function getServiceName(): ?string;
+
+    /**
      * @param array $headers
      * @return IHttpClient
      */

--- a/src/Http/IHttpClient.php
+++ b/src/Http/IHttpClient.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace MadeiraMadeiraBr\HttpClient\Http;
+
+interface IHttpClient
+{
+    /**
+     * @param array $headers
+     * @return IHttpClient
+     */
+    public function setHeaders(array $headers): IHttpClient;
+
+    /**
+     * @param array $header
+     * @return $this
+     */
+    public function pushHeader(array $header): IHttpClient;
+
+    /**
+     * @param array $options
+     * @return IHttpClient
+     */
+    public function setOptions(array $options): IHttpClient;
+
+    /**
+     * @param array $option
+     * @return IHttpClient
+     */
+    public function pushOption(array $option): IHttpClient;
+
+    /**
+     * @param string $url
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function get(string $url, ?array $headers = null, ?array $options = null): ?array;
+
+    /**
+     * @param string $url
+     * @param array $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function post(string $url, array $body, ?array $headers = null, ?array $options = null): ?array;
+
+    /**
+     * @param string $url
+     * @param array $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function put(string $url, array $body, ?array $headers = null, ?array $options = null): ?array;
+
+    /**
+     * @param string $url
+     * @param array|null $headers
+     * @param array|null $options
+     * @return array|null
+     */
+    public function delete(string $url, ?array $headers = null, ?array $options = null): ?array;
+
+    /**
+     * @param string $method
+     * @param string $url
+     * @param array|null $body
+     * @param array|null $headers
+     * @param array|null $options
+     * @return IHttpResponse
+     */
+    public function request(
+        string $method,
+        string $url,
+        ?array $body = null,
+        ?array $headers = null,
+        ?array $options = null): IHttpResponse;
+
+    /**
+     * @return ITransaction|null
+     */
+    public function getLastTransaction(): ?ITransaction;
+
+    /**
+     * @return IHttpResponse|null
+     */
+    public function getLastResponse(): ?IHttpResponse;
+
+    /**
+     * @return string
+     */
+    public function getBaseUrl(): string;
+
+    /**
+     * @param string $baseUrl
+     * @return IHttpClient
+     */
+    public function setBaseUrl(string $baseUrl): IHttpClient;
+
+    /**
+     * @param string $url
+     * @param array|null $options
+     * @return string
+     */
+    public function getUrl(string $url, ?array $options): string;
+}

--- a/src/Http/ITransaction.php
+++ b/src/Http/ITransaction.php
@@ -14,4 +14,6 @@ interface ITransaction extends Printable
     public function run(): ITransaction;
     public function getResponse(): IHttpResponse;
     public function getRequest(): IHttpRequest;
+    public function setServiceName(?string $serviceName): ITransaction;
+    public function getServiceName(): ?string;
 }

--- a/src/Http/Transaction.php
+++ b/src/Http/Transaction.php
@@ -7,6 +7,11 @@ use MadeiraMadeiraBr\HttpClient\Curl\CurlExtractor;
 class Transaction implements ITransaction
 {
     /**
+     * @var string
+     */
+    private $serviceName;
+
+    /**
      * @var IHttpRequest
      */
     private $request;
@@ -19,6 +24,17 @@ class Transaction implements ITransaction
     public function __construct(IHttpRequest $request)
     {
         $this->request = $request;
+    }
+
+    public function setServiceName(?string $serviceName): ITransaction
+    {
+        $this->serviceName = $serviceName;
+        return $this;
+    }
+
+    public function getServiceName(): ?string
+    {
+        return $this->serviceName;
     }
 
     public function run(): ITransaction

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -5,6 +5,7 @@ namespace MadeiraMadeiraBr\HttpClient\Tests;
 use MadeiraMadeiraBr\Event\EventObserverFactory;
 use MadeiraMadeiraBr\HttpClient\BodyHandlers\JsonBodyHandler;
 use MadeiraMadeiraBr\HttpClient\EnvConfigInterface;
+use MadeiraMadeiraBr\HttpClient\Http\CacheProxyHttpClient;
 use MadeiraMadeiraBr\HttpClient\Http\HttpClient;
 use MadeiraMadeiraBr\HttpClient\Http\HttpRequest;
 use MadeiraMadeiraBr\HttpClient\Http\HttpResponse;
@@ -195,5 +196,13 @@ class HttpClientTest extends TestCase
             ['curlSettings' => [CURLOPT_TIMEOUT_MS => 10]]);
 
         $this->assertInstanceOf(ITransaction::class, Observer::$eventResult);
+    }
+
+    public function testCacheReturn()
+    {
+        $httpClient = new HttpClient();
+        $cacheClient = new CacheProxyHttpClient($httpClient);
+        $cacheClient->get('https://jsonplaceholder.typicode.com/posts/1');
+        $cacheClient->get('https://jsonplaceholder.typicode.com/posts/1');
     }
 }

--- a/tests/HttpClientTest.php
+++ b/tests/HttpClientTest.php
@@ -5,7 +5,6 @@ namespace MadeiraMadeiraBr\HttpClient\Tests;
 use MadeiraMadeiraBr\Event\EventObserverFactory;
 use MadeiraMadeiraBr\HttpClient\BodyHandlers\JsonBodyHandler;
 use MadeiraMadeiraBr\HttpClient\EnvConfigInterface;
-use MadeiraMadeiraBr\HttpClient\Http\CacheProxyHttpClient;
 use MadeiraMadeiraBr\HttpClient\Http\HttpClient;
 use MadeiraMadeiraBr\HttpClient\Http\HttpRequest;
 use MadeiraMadeiraBr\HttpClient\Http\HttpResponse;
@@ -185,7 +184,7 @@ class HttpClientTest extends TestCase
 
     public function testCurlErrorCompliance()
     {
-        EventObserverFactory::getInstance()->addObserversToEvent('HTTP_CLIENT_CURL_ERROR',
+        EventObserverFactory::getInstance()->addObserversToEvent(EnvConfigInterface::CURL_ERROR_ALERT,
             [
                 Observer::class
             ]);
@@ -198,11 +197,10 @@ class HttpClientTest extends TestCase
         $this->assertInstanceOf(ITransaction::class, Observer::$eventResult);
     }
 
-    public function testCacheReturn()
-    {
-        $httpClient = new HttpClient();
-        $cacheClient = new CacheProxyHttpClient($httpClient);
-        $cacheClient->get('https://jsonplaceholder.typicode.com/posts/1');
-        $cacheClient->get('https://jsonplaceholder.typicode.com/posts/1');
-    }
+//    public function testCacheReturn()
+//    {
+//        $httpClient = new HttpClient();
+//        $cacheClient = new CacheProxyHttpClient($httpClient);
+//        $cacheClient->get('https://jsonplaceholder.typicode.com/posts/1');
+//    }
 }


### PR DESCRIPTION
## Summary
- When calling an URL that redirects (probably due to HTTPS), the HttpClient returns a `301 Moved Permanently`;
- Adding `CURLOPT_FOLLOWLOCATION = true` seems to solve the problem.